### PR TITLE
TSC build flag update, including configurable test run

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "typescript-assistant",
-  "version": "0.52.1",
+  "version": "0.52.2-tsc-build-attempt-2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "typescript-assistant",
-      "version": "0.52.1",
+      "version": "0.52.2-tsc-build-attempt-2.0",
       "license": "MIT",
       "dependencies": {
         "@types/chai": "4.2.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@types/prettier": "2.3.2",
         "@typescript-eslint/eslint-plugin": "4.30.0",
         "@typescript-eslint/parser": "4.30.0",
+        "async": "3.2.1",
         "chai": "4.3.4",
         "chokidar": "3.5.2",
         "eslint": "7.32.0",
@@ -992,6 +993,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/async": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.1.tgz",
+      "integrity": "sha512-XdD5lRO/87udXCMC9meWdYiR+Nq6ZjUfXidViUZGu2F1MO4T3XwZ1et0hb2++BgLfhyJwy44BGB/yx80ABx8hg=="
     },
     "node_modules/balanced-match": {
       "version": "1.0.0",
@@ -5264,6 +5270,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="
+    },
+    "async": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.1.tgz",
+      "integrity": "sha512-XdD5lRO/87udXCMC9meWdYiR+Nq6ZjUfXidViUZGu2F1MO4T3XwZ1et0hb2++BgLfhyJwy44BGB/yx80ABx8hg=="
     },
     "balanced-match": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "typescript-assistant",
-  "version": "0.52.2-tsc-build-attempt-2.1",
+  "version": "0.52.2-tsc-build-attempt-2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "typescript-assistant",
-      "version": "0.52.2-tsc-build-attempt-2.1",
+      "version": "0.52.2-tsc-build-attempt-2.2",
       "license": "MIT",
       "dependencies": {
         "@types/chai": "4.2.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "typescript-assistant",
-  "version": "0.52.2-tsc-build-attempt-2.0",
+  "version": "0.52.2-tsc-build-attempt-2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "typescript-assistant",
-      "version": "0.52.2-tsc-build-attempt-2.0",
+      "version": "0.52.2-tsc-build-attempt-2.1",
       "license": "MIT",
       "dependencies": {
         "@types/chai": "4.2.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "typescript-assistant",
-  "version": "0.52.2-tsc-build-attempt-2.2",
+  "version": "0.52.2-tsc-build-attempt-2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "typescript-assistant",
-      "version": "0.52.2-tsc-build-attempt-2.2",
+      "version": "0.52.2-tsc-build-attempt-2.3",
       "license": "MIT",
       "dependencies": {
         "@types/chai": "4.2.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-assistant",
-  "version": "0.52.2-tsc-build-attempt-2.1",
+  "version": "0.52.2-tsc-build-attempt-2.2",
   "description": "Combines and integrates professional Typescript tools into your project",
   "main": "dist/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-assistant",
-  "version": "0.52.2-tsc-build-attempt-2.0",
+  "version": "0.52.2-tsc-build-attempt-2.1",
   "description": "Combines and integrates professional Typescript tools into your project",
   "main": "dist/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-assistant",
-  "version": "0.52.2-tsc-build-attempt-2.2",
+  "version": "0.52.2-tsc-build-attempt-2.3",
   "description": "Combines and integrates professional Typescript tools into your project",
   "main": "dist/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-assistant",
-  "version": "0.52.1",
+  "version": "0.52.2-tsc-build-attempt-2.0",
   "description": "Combines and integrates professional Typescript tools into your project",
   "main": "dist/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@types/prettier": "2.3.2",
     "@typescript-eslint/eslint-plugin": "4.30.0",
     "@typescript-eslint/parser": "4.30.0",
+    "async": "3.2.1",
     "chai": "4.3.4",
     "chokidar": "3.5.2",
     "eslint": "7.32.0",

--- a/src/commands/assist.ts
+++ b/src/commands/assist.ts
@@ -5,6 +5,7 @@ export interface AssistOptions {
   statusServerPort?: number;
   format?: boolean;
   coverage?: boolean;
+  configs?: string[];
 }
 
 export function createAssistCommand(
@@ -14,7 +15,7 @@ export function createAssistCommand(
 
   return {
     execute(options: AssistOptions = {}) {
-      const { format = true, coverage = true } = options;
+      const { format = true, coverage = true, configs } = options;
 
       watcher.watchSourceFileChanged();
       if (options.statusServerPort) {
@@ -27,7 +28,7 @@ export function createAssistCommand(
         linter.start("source-files-changed", true);
       }
       nyc.start(["source-files-changed"], coverage);
-      compiler.start();
+      compiler.start(configs);
 
       return Promise.resolve(true);
     },

--- a/src/commands/assist.ts
+++ b/src/commands/assist.ts
@@ -6,6 +6,8 @@ export interface AssistOptions {
   format?: boolean;
   coverage?: boolean;
   projects?: string[];
+  testConfig?: string;
+  testsGlob?: string;
 }
 
 export function createAssistCommand(
@@ -15,7 +17,13 @@ export function createAssistCommand(
 
   return {
     execute(options: AssistOptions = {}) {
-      const { format = true, coverage = true, projects } = options;
+      const {
+        format = true,
+        coverage = true,
+        projects,
+        testConfig,
+        testsGlob,
+      } = options;
 
       watcher.watchSourceFileChanged();
       if (options.statusServerPort) {
@@ -27,7 +35,7 @@ export function createAssistCommand(
       } else {
         linter.start("source-files-changed", true);
       }
-      nyc.start(["source-files-changed"], coverage);
+      nyc.start(["source-files-changed"], coverage, testConfig, testsGlob);
       compiler.start(projects);
 
       return Promise.resolve(true);

--- a/src/commands/assist.ts
+++ b/src/commands/assist.ts
@@ -5,7 +5,7 @@ export interface AssistOptions {
   statusServerPort?: number;
   format?: boolean;
   coverage?: boolean;
-  configs?: string[];
+  projects?: string[];
 }
 
 export function createAssistCommand(
@@ -15,7 +15,7 @@ export function createAssistCommand(
 
   return {
     execute(options: AssistOptions = {}) {
-      const { format = true, coverage = true, configs } = options;
+      const { format = true, coverage = true, projects } = options;
 
       watcher.watchSourceFileChanged();
       if (options.statusServerPort) {
@@ -28,7 +28,7 @@ export function createAssistCommand(
         linter.start("source-files-changed", true);
       }
       nyc.start(["source-files-changed"], coverage);
-      compiler.start(configs);
+      compiler.start(projects);
 
       return Promise.resolve(true);
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,11 @@ yargsModule.command(
       boolean: true,
       default: true,
     },
+    config: {
+      describe: "provide tsconfigs to watch",
+      string: true,
+      type: "array",
+    },
   },
   (yargs) => {
     if (
@@ -68,6 +73,7 @@ yargsModule.command(
         statusServerPort: parseInt(yargs.port as string, 10) || 0,
         format: yargs.format,
         coverage: yargs.coverage,
+        configs: yargs.config,
       });
     } else {
       console.error("Unknown command");

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,7 @@ yargsModule.command(
       boolean: true,
       default: true,
     },
-    config: {
+    project: {
       describe: "provide tsconfigs to watch",
       string: true,
       type: "array",
@@ -73,7 +73,7 @@ yargsModule.command(
         statusServerPort: parseInt(yargs.port as string, 10) || 0,
         format: yargs.format,
         coverage: yargs.coverage,
-        configs: yargs.config,
+        projects: yargs.project,
       });
     } else {
       console.error("Unknown command");

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,14 @@ yargsModule.command(
       string: true,
       type: "array",
     },
+    testConfig: {
+      describe: "path to nyc config file",
+      string: true,
+    },
+    testsGlob: {
+      describe: "glob for test files",
+      string: true,
+    },
   },
   (yargs) => {
     if (
@@ -74,6 +82,8 @@ yargsModule.command(
         format: yargs.format,
         coverage: yargs.coverage,
         projects: yargs.project,
+        testConfig: yargs.testConfig,
+        testsGlob: yargs.testsGlob,
       });
     } else {
       console.error("Unknown command");
@@ -218,11 +228,26 @@ yargsModule.command(
 yargsModule.command(
   "pre-push",
   "Pre-push git hook for husky",
-  (yargs) => yargs.array("disable"),
+  {
+    disable: {
+      string: true,
+      type: "array",
+    },
+    testConfig: {
+      describe: "path to nyc config file",
+      string: true,
+    },
+    testsGlob: {
+      describe: "glob for test files",
+      string: true,
+    },
+  },
   (yargs) => {
     inject(createPrePushCommand)
       .execute({
-        disabledProjects: yargs.disable as string[],
+        disabledProjects: yargs.disable,
+        testConfig: yargs.testConfig,
+        testsGlob: yargs.testsGlob,
       })
       .then(failIfUnsuccessful, onFailure);
   }

--- a/src/taskrunner.ts
+++ b/src/taskrunner.ts
@@ -33,10 +33,9 @@ export let createDefaultTaskRunner = (): TaskRunner => {
       let loggerCategory = config.name;
       let logger = config.logger;
 
-      let readableCommand = command.replace(
-        `.${path.sep}node_modules${path.sep}.bin${path.sep}`,
-        ""
-      );
+      let readableCommand = command
+        .replace(`.${path.sep}node_modules${path.sep}.bin${path.sep}`, "")
+        .replace(".cmd", "");
 
       logger.log(
         loggerCategory,


### PR DESCRIPTION
Do not simply add all tsconfig.json files in one build call, separate them until more sensible logic is added. Also have the test runner be configurable to provide alternative config and globs.